### PR TITLE
attach image done

### DIFF
--- a/common.blocks/button/_attach/button_attach_photo.bemhtml.js
+++ b/common.blocks/button/_attach/button_attach_photo.bemhtml.js
@@ -1,0 +1,4 @@
+block('button').mod("attach", "photo")(
+    js()(true)
+);
+

--- a/common.blocks/button/_attach/button_attach_photo.js
+++ b/common.blocks/button/_attach/button_attach_photo.js
@@ -1,0 +1,34 @@
+modules.define('button', ['i-bem__dom', 'jquery', 'BEMHTML'],
+
+    function (provide, BEMDOM, $, BEMHTML) {
+
+        provide(BEMDOM.decl({ block: this.name, modName: 'attach', modVal: 'photo' }, {
+            onSetMod: {
+                js: {
+                    inited: function () {
+                        var that = this;
+
+                        this.bindTo('pointerclick', function () {
+                            var editor = this.findBlockOutside('compose-block'),
+                                old_modal = editor.findBlockInside('compose-modal');
+
+                            if (old_modal) {
+                                BEMDOM.destruct(old_modal.domElem);
+                            }
+
+                            that.dropElemCache('compose-modal');
+
+                            BEMDOM.append(editor.domElem, BEMHTML.apply({
+                                block: 'compose-modal',
+                                mods: { mode: 'photo' },
+                                js: true
+                            }));
+
+                        });
+                    }
+                }
+            }
+
+        }));
+
+    });

--- a/common.blocks/compose-block/compose-block.deps.js
+++ b/common.blocks/compose-block/compose-block.deps.js
@@ -1,11 +1,21 @@
-({
-    shouldDeps: [
-        {
-            block: 'pepo-textarea'
-        },
-        {
-            block: 'compose-menu'
-        }
-    ]
-})
+([
+    {
+        shouldDeps: [
+            {
+                block: 'pepo-textarea'
+            },
+            {
+                block: 'compose-menu'
+            }
+        ]
+    },
+    {
+        tech: 'js',
+        shouldDeps: [
+            { block: 'compose-modal', tech: 'bemhtml' },
+            { block: 'dropzone', tech: 'bemhtml' }
+        ]
+    }
+
+])
 

--- a/common.blocks/compose-block/compose-block.js
+++ b/common.blocks/compose-block/compose-block.js
@@ -17,8 +17,19 @@ modules.define('compose-block', ['i-bem__dom', 'jquery', 'BEMHTML'],
                         }
 
                         var that = this,
+                            tweet_image = null,
                             text_input = this.findBlockInside('textarea'),
                             send_tweet_btn = this.findBlockInside('send-tweet-btn');
+
+                        // события редактора
+
+                        this.findBlockOutside('page').on(
+                            'upload_success', // имя БЭМ-события
+                            function (event, data) {
+                                tweet_image = data.image;
+                            },
+                            that
+                        );
 
                         update_btn(send_tweet_btn, text_input);
 
@@ -43,7 +54,14 @@ modules.define('compose-block', ['i-bem__dom', 'jquery', 'BEMHTML'],
                                 {
                                     url: window.config.api_server + '/api/user/feed',
                                     type: "POST",
-                                    data: JSON.stringify({content: text_input.domElem.val()}),
+                                    data: JSON.stringify(
+                                        {
+                                            content: text_input.domElem.val(),
+                                            extras: {
+                                                image: tweet_image
+                                            }
+                                        }
+                                    ),
                                     dataType: "json",
                                     contentType: "application/json; charset=utf-8",
                                     context: this

--- a/common.blocks/compose-menu/compose-menu.bemtree.js
+++ b/common.blocks/compose-menu/compose-menu.bemtree.js
@@ -11,7 +11,7 @@ block('compose-menu')(
                         content: ['photo', 'geo', 'link'].map(function (v, i, content) {
                             var button = {
                                 block: 'button',
-                                mods: {},
+                                mods: {attach: v},
                                 mix: { block: 'compose-btn', elem: 'button' },
                                 icon: {
                                     block: 'icon',

--- a/common.blocks/compose-menu/compose-menu.deps.js
+++ b/common.blocks/compose-menu/compose-menu.deps.js
@@ -4,6 +4,10 @@
             block: 'control-group'
         },
         {
+            block: 'button',
+            mods: { attach: 'photo' }
+        },
+        {
             elem: 'left'
         },
         {

--- a/common.blocks/compose-modal/compose-modal.bemhtml.js
+++ b/common.blocks/compose-modal/compose-modal.bemhtml.js
@@ -1,0 +1,35 @@
+block('compose-modal')(
+    mod('mode', 'photo').replace()(
+        function () {
+            return {
+                block: 'compose-modal',
+                inner_blocks: [{ name: 'dropzone', js: {url: window.config.api_server + '/api/attach/image'} }]
+            };
+        }
+    ),
+    mod('mode', 'url').replace()(
+        function () {
+            return {
+                block: 'compose-modal',
+                inner_blocks: [{ name: 'url-input', js: true }]
+            };
+        }
+    ),
+    content()(function () {
+        return [
+            this.ctx.inner_blocks.map(function (block) {
+                return {
+                    elem: "modal-body",
+                    content: [
+                        {
+                            block: block.name,
+                            js: block.js
+                        }
+                    ]
+
+                };
+            })
+        ];
+    }),
+    js()(true)
+);

--- a/common.blocks/compose-modal/compose-modal.deps.js
+++ b/common.blocks/compose-modal/compose-modal.deps.js
@@ -1,0 +1,7 @@
+({
+    tech: 'js',
+    shouldDeps: [
+        { block: 'dropzone', tech: 'bemhtml' }
+    ]
+
+})

--- a/common.blocks/compose-modal/compose-modal.js
+++ b/common.blocks/compose-modal/compose-modal.js
@@ -1,0 +1,18 @@
+modules.define('compose-modal', ['i-bem__dom', 'jquery', 'BEMHTML'],
+
+    function (provide, BEMDOM, $, BEMHTML) {
+
+        provide(BEMDOM.decl(this.name, {
+            onSetMod: {
+                js: {
+                    inited: function () {
+                        console.log('hi');
+                        //this.findBlockInside('dropzone').domElem.dropzone({ url: window.config.api_server + "/api/user/feed/image" });
+                    }
+                }
+            }
+
+        }));
+
+    });
+

--- a/common.blocks/dropzone/dropzone.js
+++ b/common.blocks/dropzone/dropzone.js
@@ -10,8 +10,21 @@ modules.define('dropzone', ['i-bem__dom', 'jquery'], function (provide, BEMDOM, 
             js: {
                 inited: function () {
                     // в момент инициализации блока будет включен dropzone
-                    console.log('Dropzone');
-                    //this.domElem.dropzone({ url: '/api/user/feed/image' });
+                    var that = this;
+
+                    if (this.params.url) {
+                        this.domElem.dropzone({
+                            url: this.params.url,
+                            success: function (file, response) {
+                                var data = JSON.parse(response);
+                                //data = {image: 'test'};
+                                console.log('upload success emit!');
+                                that.findBlockOutside('page').emit('upload_success', data);
+                            }
+
+                        });
+                    }
+                    //
                 }
             }
         }

--- a/common.blocks/tweet/_default/tweet_default.js
+++ b/common.blocks/tweet/_default/tweet_default.js
@@ -17,6 +17,7 @@ modules.define('tweet', ['i-bem__dom', 'BEMHTML'], function (provide, BEMDOM, BE
                 break;
             case 'reply':
                 break;
+
             }
         }
     },
@@ -44,3 +45,4 @@ modules.define('tweet', ['i-bem__dom', 'BEMHTML'], function (provide, BEMDOM, BE
             }
         }));
 });
+


### PR DESCRIPTION
Прикрепление картинки к твиту, при составлении сообщения. Добавлен блок compose-modal, через который мы и делаем прикрепление дополнений к твиту. TODO: получить от сервера url, куда льем картинки, и синхронизировать формат ответа. Сейчас читается поле image json объекта ответа.
